### PR TITLE
Fix: Filter disabled models in smart and expert routing

### DIFF
--- a/src/routes/proxy/routing.ts
+++ b/src/routes/proxy/routing.ts
@@ -316,6 +316,7 @@ export async function resolveSmartRouting(
       // 从 provider 下查找匹配的真实模型
       const providerModels = await modelDb.getByProviderId(selectedTarget.provider);
       resolvedModel = providerModels.find(m =>
+        m.enabled === 1 &&
         m.is_virtual !== 1 && (
           m.model_identifier === selectedTarget.override_params!.model ||
           m.name === selectedTarget.override_params!.model
@@ -417,6 +418,7 @@ export async function resolveExpertRouting(
       // 从 provider 下查找匹配的真实模型（类似智能路由的处理）
       const providerModels = await modelDb.getByProviderId(result.providerId);
       resolvedModel = providerModels.find(m =>
+        m.enabled === 1 &&
         m.is_virtual !== 1 && (
           m.model_identifier === result.modelOverride ||
           m.name === result.modelOverride


### PR DESCRIPTION
## What
Add enabled status check to model resolution in routing logic.

## Why
Disabled models were being selected during routing, causing requests to be sent to models that administrators had explicitly disabled.

## How
- Add `m.enabled === 1` condition to model filtering in `resolveSmartRouting()`
- Add `m.enabled === 1` condition to model filtering in `resolveExpertRouting()`
- Ensure only enabled models are considered during routing resolution

## Impact
- Respects model enable/disable configuration
- Prevents routing to disabled models
- No breaking changes to existing API
